### PR TITLE
docker-compose: remove depends_on

### DIFF
--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -13,5 +13,3 @@ services:
     command: |
       -ipc /data/geth.ipc
       -port {{ geth_expo_cont_port }}
-    depends_on:
-      - 'geth'


### PR DESCRIPTION
When doing disk upgrades on nimbus.holesky fleet for geth nodes, I've noticed the docker compose commands on geth exporter were failing because there was a depends_on property:
```bash
mburcul@geth-01.ih-eu-mda1.nimbus.holesky:~ % docker compose -f /docker/geth-holesky-02/docker-compose.exporter.yml down
WARN[0000] /docker/geth-holesky-02/docker-compose.exporter.yml: `version` is obsolete 
service "metrics" depends on undefined service "geth": invalid compose project
```